### PR TITLE
Document stricter note mapping tolerance

### DIFF
--- a/tool/validate.dart
+++ b/tool/validate.dart
@@ -20,7 +20,7 @@ Future<void> main() async {
 }
 
 /// Validate that frequency-to-note mapping produces expected results within
-/// ±5 cents.
+/// ±0.01 cent.
 bool testNoteMapping() {
   print('Test: frequency to note and cents mapping');
   final baseA4 = 440.0;


### PR DESCRIPTION
## Summary
- clarify note mapping test tolerance to ±0.01 cent

## Testing
- `dart run tool/validate.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6cd5287048332a582257d88c1ed39